### PR TITLE
New features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^16.11.36",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.5",
+        "array-move": "^4.0.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "^5.0.1",
@@ -4271,6 +4272,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-move": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-4.0.0.tgz",
+      "integrity": "sha512-+RY54S8OuVvg94THpneQvFRmqWdAHeqtMzgMW6JNurHxe8rsS07cHQdfGkXnTUXiBcyZ0j3SiDIxxj0RPiqCkQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/array-union": {
@@ -19307,6 +19319,11 @@
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
+    },
+    "array-move": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-4.0.0.tgz",
+      "integrity": "sha512-+RY54S8OuVvg94THpneQvFRmqWdAHeqtMzgMW6JNurHxe8rsS07cHQdfGkXnTUXiBcyZ0j3SiDIxxj0RPiqCkQ=="
     },
     "array-union": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^16.11.36",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.5",
+    "array-move": "^4.0.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,42 +16,46 @@ function App() {
     useContext<CountersContextProps>(CountersContext);
   // return how many counters are hidden
   const visibleCount = counters.reduce((acc, counter) => {
-    if (!counter.hidden) {
-      return acc + 1;
-    } else {
-      return acc;
-    }
+    return acc + (counter.hidden ? 0 : 1);
   }, 0);
 
   return (
     <div className="main-div">
-      <div
-        className="grid-container"
-        style={{ gridTemplateColumns: `90px repeat(${visibleCount}, 1fr)` }}
-      >
-        <InfoCell></InfoCell>
-        <HeaderTable></HeaderTable>
-        <SyndicateRow
-          rowIndex={3}
-          letter={"T"}
-          areaName={"transportation"}
-        ></SyndicateRow>
-        <SyndicateRow
-          rowIndex={2}
-          letter={"F"}
-          areaName={"fortification"}
-        ></SyndicateRow>
-        <SyndicateRow
-          rowIndex={1}
-          letter={"R"}
-          areaName={"research"}
-        ></SyndicateRow>
-        <SyndicateRow
-          rowIndex={0}
-          letter={"I"}
-          areaName={"intervention"}
-        ></SyndicateRow>
-      </div>
+      {visibleCount === 0 && (
+        <div className="grid-item all-hidden">
+          <h1>Ops, you are trying to hide everyone!</h1>
+        </div>
+      )}
+      {visibleCount > 0 && (
+        <div
+          className="grid-container"
+          style={{ gridTemplateColumns: `90px repeat(${visibleCount}, 1fr)` }}
+        >
+          <InfoCell></InfoCell>
+
+          <HeaderTable></HeaderTable>
+          <SyndicateRow
+            rowIndex={3}
+            letter={"T"}
+            areaName={"transportation"}
+          ></SyndicateRow>
+          <SyndicateRow
+            rowIndex={2}
+            letter={"F"}
+            areaName={"fortification"}
+          ></SyndicateRow>
+          <SyndicateRow
+            rowIndex={1}
+            letter={"R"}
+            areaName={"research"}
+          ></SyndicateRow>
+          <SyndicateRow
+            rowIndex={0}
+            letter={"I"}
+            areaName={"intervention"}
+          ></SyndicateRow>
+        </div>
+      )}
       <div className="menu">
         <HiddenRow></HiddenRow>
         <Share></Share>

--- a/src/component/HeaderTable/HeaderTable.scss
+++ b/src/component/HeaderTable/HeaderTable.scss
@@ -20,4 +20,12 @@
   justify-content: space-between;
   align-items: center;
   margin-top: auto;
+  .arrow {
+    background-color: rgba(19, 19, 19, 0.5);
+    padding: 5px;
+    max-width: 15px;
+    max-height: 15px;
+    border-radius: 20px;
+    // box-shadow: #000000 0px 0px 10px, #000000 0px 0px 5px;
+  }
 }

--- a/src/component/HeaderTable/HeaderTable.scss
+++ b/src/component/HeaderTable/HeaderTable.scss
@@ -13,3 +13,11 @@
   text-align: center;
   text-shadow: 0px 0px 10px #000000, 0px 0px 5px #000000, 0px 0px 5px #000000;
 }
+
+.directions {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+}

--- a/src/component/HeaderTable/HeaderTable.tsx
+++ b/src/component/HeaderTable/HeaderTable.tsx
@@ -1,11 +1,17 @@
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 import { CountersContext } from "../../context/counters";
 import { SyndicateContext } from "../../context/members";
 import { CountersContextProps } from "../../interfaces/CountersContextProps";
 import { ISyndicate } from "../../interfaces/ISyndicate";
 import IncrementOnPosition from "../../utils/IncrementOnPosition";
+import { arrayMoveImmutable } from "array-move";
 
 import "./HeaderTable.scss";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faChevronLeft,
+  faChevronRight,
+} from "@fortawesome/free-solid-svg-icons";
 
 const HeaderTable = () => {
   const { members } = useContext<ISyndicate>(SyndicateContext);
@@ -21,9 +27,35 @@ const HeaderTable = () => {
     });
   };
 
+  const [shiftedMembers, setShiftedMembers] = useState(
+    arrayMoveImmutable(members, 0, 0)
+  );
+  const handleMove = (direction: number, memberPosition: number) => {
+    //-1 left, +1 right
+    var newPosition = memberPosition + direction;
+    if (newPosition < 0) {
+      newPosition = members.length - 1;
+    }
+    if (newPosition > members.length - 1) {
+      newPosition = 0;
+    }
+    setShiftedMembers((previousMembers) => {
+      return arrayMoveImmutable(previousMembers, memberPosition, newPosition);
+    });
+    setCounters((previousCounters) => {
+      return arrayMoveImmutable(previousCounters, memberPosition, newPosition);
+    });
+  };
+
+  // useEffect(() => {
+  //   // console.log(counters);
+  //   setShiftedCounters(arrayMoveImmutable(counters, 0, 0));
+  //   console.log(shiftedCounters);
+  // }, []);
+
   return (
     <>
-      {members.map((member, index) => (
+      {shiftedMembers.map((member, index) => (
         <div
           key={member.name}
           className={`grid-item member-img clickable color${
@@ -37,6 +69,22 @@ const HeaderTable = () => {
           }}
           onClick={() => handleCounter(member.name)}
         >
+          {/* <div className="directions">
+            <span
+              onClick={() => {
+                handleMove(-1, index);
+              }}
+            >
+              <FontAwesomeIcon icon={faChevronLeft} size="lg" />
+            </span>
+            <span
+              onClick={() => {
+                handleMove(+1, index);
+              }}
+            >
+              <FontAwesomeIcon icon={faChevronRight} size="lg" />
+            </span>
+          </div> */}
           <div className="member-name">{member.name}</div>
         </div>
       ))}

--- a/src/component/HeaderTable/HeaderTable.tsx
+++ b/src/component/HeaderTable/HeaderTable.tsx
@@ -8,14 +8,11 @@ import { arrayMoveImmutable } from "array-move";
 
 import "./HeaderTable.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faChevronLeft,
-  faChevronRight,
-} from "@fortawesome/free-solid-svg-icons";
+import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
 
 const HeaderTable = () => {
   const { members } = useContext<ISyndicate>(SyndicateContext);
-  const { counters, setCounters } =
+  const { counters, setCounters, positions, setPositions } =
     useContext<CountersContextProps>(CountersContext);
   const handleCounter = (member: string) => {
     const found = counters.find((item) => item.field === member);
@@ -27,65 +24,69 @@ const HeaderTable = () => {
     });
   };
 
-  const [shiftedMembers, setShiftedMembers] = useState(
-    arrayMoveImmutable(members, 0, 0)
-  );
-  const handleMove = (direction: number, memberPosition: number) => {
+  const handleMove = (
+    //event is a mouseevent
+    event: React.MouseEvent<HTMLSpanElement, MouseEvent>,
+    direction: number,
+    memberPosition: number
+  ) => {
+    event.stopPropagation();
     //-1 left, +1 right
     var newPosition = memberPosition + direction;
+    // position goes around if it goes out of bounds
     if (newPosition < 0) {
       newPosition = members.length - 1;
     }
     if (newPosition > members.length - 1) {
       newPosition = 0;
     }
-    setShiftedMembers((previousMembers) => {
-      return arrayMoveImmutable(previousMembers, memberPosition, newPosition);
-    });
-    setCounters((previousCounters) => {
-      return arrayMoveImmutable(previousCounters, memberPosition, newPosition);
+    setPositions((previousPositions) => {
+      return arrayMoveImmutable(previousPositions, memberPosition, newPosition);
     });
   };
 
-  // useEffect(() => {
-  //   // console.log(counters);
-  //   setShiftedCounters(arrayMoveImmutable(counters, 0, 0));
-  //   console.log(shiftedCounters);
-  // }, []);
-
   return (
     <>
-      {shiftedMembers.map((member, index) => (
+      {members.map((member, index) => (
         <div
           key={member.name}
           className={`grid-item member-img clickable color${
-            counters[index]
-              ? String(counters[index].count).padStart(5, "0")[4]
+            counters[positions[index]]
+              ? String(counters[positions[index]].count).padStart(5, "0")[4]
               : "0"
           }`}
           style={{
-            backgroundImage: `url(${process.env.PUBLIC_URL}/${member.img})`,
-            display: counters[index]?.hidden ? "none" : "flex",
+            backgroundImage: `url(${process.env.PUBLIC_URL}/${
+              members[positions[index]].img
+            })`,
+            display: counters[positions[index]]?.hidden ? "none" : "flex",
           }}
-          onClick={() => handleCounter(member.name)}
+          onClick={() => handleCounter(members[positions[index]].name)}
         >
-          {/* <div className="directions">
+          <div className="directions">
             <span
-              onClick={() => {
-                handleMove(-1, index);
+              onClick={(event) => {
+                handleMove(event, -1, index);
               }}
             >
-              <FontAwesomeIcon icon={faChevronLeft} size="lg" />
+              <FontAwesomeIcon className="arrow" icon={faArrowLeft} size="lg" />
             </span>
             <span
-              onClick={() => {
-                handleMove(+1, index);
+              onClick={(event) => {
+                handleMove(event, +1, index);
               }}
             >
-              <FontAwesomeIcon icon={faChevronRight} size="lg" />
+              <FontAwesomeIcon
+                className="arrow"
+                icon={faArrowRight}
+                size="lg"
+              />
             </span>
-          </div> */}
-          <div className="member-name">{member.name}</div>
+          </div>
+          <div className="member-name">
+            {/* {member.name} - {positions[index]} -{" "} */}
+            {members[positions[index]].name}
+          </div>
         </div>
       ))}
     </>

--- a/src/component/HiddenRow/HiddenRow.scss
+++ b/src/component/HiddenRow/HiddenRow.scss
@@ -1,6 +1,6 @@
 .hide-member-container {
   width: 100%;
-  height: 110px;
+  height: 100%;
   display: flex;
   flex-direction: row;
   justify-content: flex-start;

--- a/src/component/Share/Share.scss
+++ b/src/component/Share/Share.scss
@@ -16,11 +16,11 @@
 
 .share-area {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: flex-start;
   align-items: center;
   width: 100%;
-  height: 110px;
+  height: 100%;
   border: 1px solid rgba(196, 154, 124, 0.3);
   background-color: #1a1a1a;
   -webkit-box-shadow: inset 0px 0px 10px 2px rgba(196, 154, 124, 0.2);
@@ -28,11 +28,13 @@
   box-shadow: inset 0px 0px 10px 2px rgba(196, 154, 124, 0.2);
   padding: 5px;
   border-radius: 5px;
-  .share-container {
+  .share-container,
+  .clear-container,
+  .load-defaultcode-container {
     width: 100%;
-  }
-  .clear-container {
-    width: 100%;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
   }
 }
 
@@ -40,7 +42,9 @@
   color: rgb(255, 210, 171);
   font-size: clamp(0.6rem, 0.9vw, 0.8rem);
   margin-left: 5px;
+  line-height: 12px;
 }
+// Took from Pathofexile.com
 .button-text {
   font-family: inherit;
   -webkit-user-select: none;

--- a/src/component/Share/Share.tsx
+++ b/src/component/Share/Share.tsx
@@ -34,9 +34,6 @@ const Share = () => {
     toast("Copied to Clipboard!");
   };
 
-  // useEffect(() => {
-  //   console.log(shareCode);
-  // }, [shareCode]);
   return (
     <div className="share-area">
       <ToastContainer

--- a/src/component/Share/Share.tsx
+++ b/src/component/Share/Share.tsx
@@ -7,11 +7,14 @@ import "react-toastify/dist/ReactToastify.css";
 
 import "./Share.scss";
 import Button from "../Button/Button";
+import ShareCodeSplitter from "../../utils/ShareCodeSplitter";
+import { ISyndicate } from "../../interfaces/ISyndicate";
+import { SyndicateContext } from "../../context/members";
 
 const Share = () => {
   const { counters, setCounters, setShareCode } =
     useContext<CountersContextProps>(CountersContext);
-
+  const { members } = useContext<ISyndicate>(SyndicateContext);
   const resetCounters = () => {
     setCounters((previousCounters) => {
       return previousCounters.map((counter) => {
@@ -19,6 +22,22 @@ const Share = () => {
       });
     });
     toast("Cleared!");
+  };
+
+  const loadDefaultCounters = () => {
+    const defaultShareCode: string =
+      "0200112001000032301200013233310211112002211002000001101011012301100000220122212202112";
+    members.forEach((member, columnIndex) => {
+      const loadedCounter = ShareCodeSplitter(defaultShareCode, columnIndex);
+      const found = counters.find((item) => item.field === member.name);
+      if (found) {
+        found.count = loadedCounter;
+      }
+    });
+    setCounters((previousCounters) => {
+      return [...previousCounters];
+    });
+    toast("Loaded!");
   };
 
   const handleShare = async () => {
@@ -50,18 +69,15 @@ const Share = () => {
         closeButton={false}
       />
       <div className="share-container">
-        <Button onClick={() => handleShare()} width="250px" fontSize="1.25rem">
-          Copy to Clipboard
+        <Button onClick={() => handleShare()} width="300px" fontSize="1.25rem">
+          Copy Code to Clipboard
         </Button>
-        <span className="share-info">
-          This will copy the share url to your clipboard. Anybody opening that
-          link will see the same Cheat Sheet as you.
-        </span>
+        <span className="share-info">It will make an URL for you!</span>
       </div>
       <div className="clear-container">
         <Button
           onClick={() => resetCounters()}
-          width="250px"
+          width="300px"
           fontSize="1.25rem"
         >
           Clear Cheat Sheet
@@ -69,6 +85,16 @@ const Share = () => {
         <span className="share-info">
           This will clear your Betrayal Cheat Sheet.
         </span>
+      </div>
+      <div className="load-defaultcode-container">
+        <Button
+          onClick={() => loadDefaultCounters()}
+          width="300px"
+          fontSize="1.25rem"
+        >
+          Load Default
+        </Button>
+        <span className="share-info">The most common cheat sheet.</span>
       </div>
     </div>
   );

--- a/src/component/SyndicateRow/SyndicateRow.tsx
+++ b/src/component/SyndicateRow/SyndicateRow.tsx
@@ -14,7 +14,7 @@ const SyndicateRow = ({
   areaName = "transportation",
 }) => {
   const { members } = useContext<ISyndicate>(SyndicateContext);
-  const { counters, setCounters, setShareCode } =
+  const { counters, setCounters, setShareCode, positions, setPositions } =
     useContext<CountersContextProps>(CountersContext);
   const handleCounter = (member: string) => {
     const found = counters.find((item) => item.field === member);
@@ -51,39 +51,49 @@ const SyndicateRow = ({
         <div
           key={member.name}
           className={`grid-item clickable item-img color${
-            counters[index]
-              ? String(counters[index].count).padStart(5, "0")[rowIndex]
+            counters[positions[index]]
+              ? String(counters[positions[index]].count).padStart(5, "0")[
+                  rowIndex
+                ]
               : "0"
           }`}
-          onClick={() => handleCounter(member.name)}
+          onClick={() => handleCounter(members[positions[index]].name)}
           // backgroundImage diferent based on areaName
           style={{
             backgroundImage: `url(${process.env.PUBLIC_URL}/${
               areaName === "transportation"
-                ? member.transportationImg
+                ? members[positions[index]].transportationImg
                 : areaName === "fortification"
-                ? member.fortificationImg
+                ? members[positions[index]].fortificationImg
                 : areaName === "research"
-                ? member.researchImg
+                ? members[positions[index]].researchImg
                 : areaName === "intervention"
-                ? member.interventionImg
+                ? members[positions[index]].interventionImg
                 : ""
             })`,
             // display is none if hidden is true
-            display: counters[index]?.hidden ? "none" : "flex",
+            display: counters[positions[index]]?.hidden ? "none" : "flex",
           }}
         >
           {areaName === "transportation" && (
-            <div className="item-text">{member.transportation}</div>
+            <div className="item-text">
+              {members[positions[index]].transportation}
+            </div>
           )}
           {areaName === "fortification" && (
-            <div className="item-text">{member.fortification}</div>
+            <div className="item-text">
+              {members[positions[index]].fortification}
+            </div>
           )}
           {areaName === "research" && (
-            <div className="item-text">{member.research}</div>
+            <div className="item-text">
+              {members[positions[index]].research}
+            </div>
           )}
           {areaName === "intervention" && (
-            <div className="item-text">{member.intervention}</div>
+            <div className="item-text">
+              {members[positions[index]].intervention}
+            </div>
           )}
         </div>
       ))}

--- a/src/context/counters.tsx
+++ b/src/context/counters.tsx
@@ -14,12 +14,17 @@ export const CountersContext = createContext<CountersContextProps>({
   setCounters: () => {},
   shareCode: "",
   setShareCode: () => {},
+  positions: [],
+  setPositions: () => {},
 });
 
 export const CountersProvider = (props: CountersProps) => {
   const { members } = useContext<ISyndicate>(SyndicateContext);
   const [counters, setCounters] = useState<ICounters>([]);
-
+  // 0 = Aisling, 1 = Cameria .... 16 = Vorici --- Alphabetically distributed
+  const [positions, setPositions] = useState<Array<number>>([
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+  ]);
   const [shareCode, setShareCode] = useState<string>(
     CodeValidator(window.location.href)
   );
@@ -35,7 +40,12 @@ export const CountersProvider = (props: CountersProps) => {
           setCounters((previousCounters) => {
             return [
               ...previousCounters,
-              { field: member.name, count: loadedCounter, hidden: false },
+              {
+                field: member.name,
+                count: loadedCounter,
+                hidden: false,
+                positions: [columnIndex],
+              },
             ];
           });
         }
@@ -47,7 +57,14 @@ export const CountersProvider = (props: CountersProps) => {
     localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(counters));
   }, [counters]);
 
-  const value = { counters, setCounters, shareCode, setShareCode };
+  const value = {
+    counters,
+    setCounters,
+    shareCode,
+    setShareCode,
+    positions,
+    setPositions,
+  };
   return (
     <CountersContext.Provider value={value}>
       {props.children}

--- a/src/index.scss
+++ b/src/index.scss
@@ -15,6 +15,7 @@
 }
 
 body {
+  background-color: rgb(19, 19, 19);
   margin: 0;
   font-family: "Fontin", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
     "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;

--- a/src/interfaces/CountersContextProps.tsx
+++ b/src/interfaces/CountersContextProps.tsx
@@ -5,4 +5,6 @@ export interface CountersContextProps {
   setCounters: React.Dispatch<React.SetStateAction<ICounters>>;
   shareCode: string;
   setShareCode: React.Dispatch<React.SetStateAction<string>>;
+  positions: Array<number>;
+  setPositions: React.Dispatch<React.SetStateAction<Array<number>>>;
 }

--- a/src/interfaces/ICounters.tsx
+++ b/src/interfaces/ICounters.tsx
@@ -2,6 +2,7 @@ export interface ICountersValue {
   field: string;
   count: number;
   hidden: boolean;
+  positions: Array<number>;
 }
 
 export interface ICounters extends Array<ICountersValue> {}

--- a/src/interfaces/IMembers.tsx
+++ b/src/interfaces/IMembers.tsx
@@ -1,4 +1,4 @@
-export interface IMembers {
+export interface IMembersValue {
   name: string;
   img: string;
   transportation: string;
@@ -10,3 +10,5 @@ export interface IMembers {
   intervention: string;
   interventionImg: string;
 }
+
+export interface IMembers extends Array<IMembersValue> {}

--- a/src/interfaces/ISyndicate.tsx
+++ b/src/interfaces/ISyndicate.tsx
@@ -1,5 +1,5 @@
 import { IMembers } from "./IMembers";
 
 export interface ISyndicate {
-  members: IMembers[];
+  members: IMembers;
 }


### PR DESCRIPTION
Tried to refactor members context but instead added a positions array to counters. This way members say "static", only loading the provided json, while counters have different states being managed all the time.

- Fixed bug when hidding all members.
- Added feature to move members positions
- Improved responsiveness for smaller screen (1200px or more still). I don't see people using it on mobile.
- Added button to load a default cheat sheet which is a good one. This is most used in case you accidentaly clicked to clear it or just want to have the default already.